### PR TITLE
ホットリロードを設定(コードを変更するたびにサーバーを起動したり、止めたりする必要がなくなる)

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()//これはHTTPリクエストを処理
+	r.GET("/ping", func(c *gin.Context) {//ルーターにクライアントのリクエスト先となるエンドポイントを追加
+		c.JSON(200, gin.H{
+			"message": "pong",
+		})
+	})
+	r.Run("localhost:8080")
+}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import "github.com/gin-gonic/gin"
 
 func main() {
 	r := gin.Default()//これはHTTPリクエストを処理
-	r.GET("/ping", func(c *gin.Context) {//ルーターにクライアントのリクエスト先となるエンドポイントを追加
+	r.GET("/sample", func(c *gin.Context) {//ルーターにクライアントのリクエスト先となるエンドポイントを追加
 		c.JSON(200, gin.H{
 			"message": "pong",
 		})


### PR DESCRIPTION
## ホットリロード
コードを変更するたびにサーバーを起動したり、止めたりすると面倒なので```ホットリロード```します。

```
go install github.com/air-verse/air@latest
```
https://github.com/air-verse/air

その後、(Mac想定)
```
echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.bashrc
```
または
```
echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.zshrc
```
を実行する。その後に
```
air init
```
を実行して```.air.toml```を作成されます。

```
air
```
で***サーバーを起動し、コードを変更すると再ビルドされコードの反映***がされます。